### PR TITLE
Add support for cancel event in file selection input

### DIFF
--- a/dev/example.html
+++ b/dev/example.html
@@ -206,7 +206,7 @@
 
             progressBar.classList.add('hidden');
 
-            message.innerText = '❌ Error ' + response.code;
+            message.innerText = '❌ Error ' + (typeof response === 'string' ? response : response.code);
             message.classList.remove('hidden');
 
             spinner.classList.add('hidden');

--- a/src/utils.js
+++ b/src/utils.js
@@ -170,6 +170,26 @@ module.exports = class Utils {
       }, false);
 
       /**
+       * Detect if the browser supports the `cancel` event
+       */
+      if ('oncancel' in inputElement) {
+        /**
+         * Add oncancel listener for «choose file» pop-up
+         */
+        inputElement.addEventListener('cancel', () => {
+          /**
+           * Reject promise if user canceled file selection
+           */
+          reject('User canceled file selection');
+
+          /**
+           * Remove element from a DOM
+           */
+          document.body.removeChild(inputElement);
+        });
+      }
+
+      /**
        * Fire click event on «input file» field
        */
       inputElement.click();


### PR DESCRIPTION
This PR adds the ability to listen for the cancel event. When the cancel event is fired, the promise is rejected.

Currently, if the user cancels the upload, the promise is always in pending state, which should not make sense.

I am using this great library to implement image upload functionality. Currently I need to listen to the user's cancel action. I'm sure others will have this need as well.

Modern browsers already implement the Input's Cancel event, so it only takes a small amount of code to implement this functionality.

**references:**
1. https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/cancel_event
2. https://caniuse.com/mdn-api_htmlinputelement_cancel_event

fixed: #50 